### PR TITLE
Fix bobber rethrow in multiplayer motion monitor

### DIFF
--- a/src/main/java/troy/autofish/monitor/FishMonitorMPMotion.java
+++ b/src/main/java/troy/autofish/monitor/FishMonitorMPMotion.java
@@ -14,12 +14,18 @@ import troy.autofish.Autofish;
 
 public class FishMonitorMPMotion implements FishMonitorMP {
 
+    // The threshold of detecting a bobber moving downwards, to detect as a fish.
     public static final int PACKET_MOTION_Y_THRESHOLD = -350;
 
-    //True if the hook hit water then started to rise.
-    private boolean catchable = false;
-    private long catchableAt = 0L;
+    // Start catching fish after a 1 second threshold.
+    public static final int START_CATCHING_AFTER_THRESHOLD = 1000;
+
+    // True if the bobber is in the water.
     private boolean hasHitWater = false;
+    
+    // Time at which bobber begins to rise in the water.
+    // 0 if the bobber has not rose in the water yet.
+    private long bobberRiseTimestamp = 0;
 
 
     @Override
@@ -32,6 +38,7 @@ public class FishMonitorMPMotion implements FishMonitorMP {
     @Override
     public void handleHookRemoved() {
         hasHitWater = false;
+        bobberRiseTimestamp = 0;
     }
 
     @Override
@@ -40,16 +47,24 @@ public class FishMonitorMPMotion implements FishMonitorMP {
             EntityVelocityUpdateS2CPacket velocityPacket = (EntityVelocityUpdateS2CPacket) packet;
             if (minecraft.player != null && minecraft.player.fishHook != null && minecraft.player.fishHook.getEntityId() == velocityPacket.getId()) {
 
-                //hook starts to rise after sinking in water
-                if (hasHitWater && !catchable && velocityPacket.getVelocityY() > 0) {
-                    catchable = true;
-                    catchableAt = autofish.timeMillis;
+                // Wait until the bobber has rose in the water.
+                // Prevent remarking the bobber rise timestamp until it is reset by catching.
+                if (hasHitWater && bobberRiseTimestamp == 0 && velocityPacket.getVelocityY() > 0) {
+                    // Mark the time in which the bobber began to rise.
+                    bobberRiseTimestamp = autofish.timeMillis;
                 }
 
-                if (hasHitWater && catchable && (autofish.timeMillis - catchableAt > 500)) {
+                // Calculate the time in which the bobber has been in the water
+                long timeInWater = autofish.timeMillis - bobberRiseTimestamp;
+
+                // If the bobber has been in the water long enough, start detecting the bobber movement.
+                if (hasHitWater && bobberRiseTimestamp != 0 && timeInWater > START_CATCHING_AFTER_THRESHOLD) {
                     if (velocityPacket.getVelocityX() == 0 && velocityPacket.getVelocityZ() == 0 && velocityPacket.getVelocityY() < PACKET_MOTION_Y_THRESHOLD) {
+                        // Catch the fish
                         autofish.catchFish();
-                        hasHitWater = false;
+
+                        // Reset the class attributes to default.
+                        this.handleHookRemoved();
                     }
                 }
             }


### PR DESCRIPTION
## Motivation
In the past, the `catchableAt` timetamp is not reset when the bobber is removed, which means a falling bobber thrown at a wall may cause a rod to rethrow. (because x and z velocities are 0).

## Bug Details
1. Place a temporary print statement  
    ![image](https://user-images.githubusercontent.com/13886925/121603271-6835b500-ca40-11eb-84f3-94e932d5cf03.png)
2. Throw a rod against a wall, negating the x and z velocities
3. The bobber may be detected as a "catch", even though no time has elapsed.

https://user-images.githubusercontent.com/13886925/121602917-eba2d680-ca3f-11eb-8855-5e28196de69c.mp4


## Changes
This PR changes the name of this variable to a better name, as well as:

- Resetting the timestamp to 0 when the bobber is removed.
- Making sure the timestamp cannot be reset until the bobber is removed
- Making sure the catch can occur only 1000ms after the bobber has risen in the water.
