### PR TITLE
update autofish to support minecraft 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -11,8 +11,10 @@ group = project.maven_group
 
 def includeDep = true
 
+/*
 minecraft {
 }
+ */
 
 repositories {
 	maven { url "https://maven.shedaniel.me/" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 0.9.4
+mod_version = 0.9.5
 maven_group = troy.autofish
 archives_base_name = autofish
 
 # Fabric Properties
-# check these on https://modmuss50.me/fabric.html or https://fabricmc.net/use
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.3
-loader_version=0.12.11
+# check these on https://fabricmc.net/develop/
+minecraft_version=1.19
+yarn_mappings=1.19+build.2
+loader_version=0.14.7
 
-#Fabric API
-fabric_version=0.44.0+1.18
+#Fabric api
+fabric_version=0.56.0+1.19
 
 #Cloth Config API
-cloth_config_version=6.1.48
+cloth_config_version=7.0.72

--- a/src/main/java/troy/autofish/Autofish.java
+++ b/src/main/java/troy/autofish/Autofish.java
@@ -114,7 +114,7 @@ public class Autofish {
                         if (org.apache.commons.lang3.StringUtils.deleteWhitespace(modAutofish.getConfig().getClearLagRegex()).isEmpty())
                             return;
                         //check if it matches
-                        Matcher matcher = Pattern.compile(modAutofish.getConfig().getClearLagRegex(), Pattern.CASE_INSENSITIVE).matcher(StringHelper.stripTextFormat(packet.getMessage().getString()));
+                        Matcher matcher = Pattern.compile(modAutofish.getConfig().getClearLagRegex(), Pattern.CASE_INSENSITIVE).matcher(StringHelper.stripTextFormat(packet.comp_763().getString()));
                         if (matcher.find()) {
                             queueRecast();
                         }
@@ -190,7 +190,7 @@ public class Autofish {
     public void useRod() {
         if(client.player != null && client.world != null) {
             Hand hand = getCorrectHand();
-            ActionResult actionResult = client.interactionManager.interactItem(client.player, client.world, hand);
+            ActionResult actionResult = client.interactionManager.interactItem(client.player, hand);
             if (actionResult.isAccepted()) {
                 if (actionResult.shouldSwingHand()) {
                     client.player.swingHand(hand);

--- a/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
+++ b/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
@@ -8,7 +8,7 @@ import me.shedaniel.clothconfig2.impl.builders.SubCategoryBuilder;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import troy.autofish.FabricModAutofish;
 import troy.autofish.config.Config;
 
@@ -17,8 +17,8 @@ import java.util.function.Function;
 public class AutofishScreenBuilder {
 
     private static final Function<Boolean, Text> yesNoTextSupplier = bool -> {
-        if (bool) return new TranslatableText("options.autofish.toggle.on");
-        else return new TranslatableText("options.autofish.toggle.off");
+        if (bool) return Text.translatable("options.autofish.toggle.on");
+        else return Text.translatable("options.autofish.toggle.off");
     };
 
     public static Screen buildScreen(FabricModAutofish modAutofish, MinecraftClient client) {
@@ -28,7 +28,7 @@ public class AutofishScreenBuilder {
 
         ConfigBuilder builder = ConfigBuilder.create()
                 .setParentScreen(client.currentScreen)
-                .setTitle(new TranslatableText("options.autofish.title"))
+                .setTitle(Text.translatable("options.autofish.title"))
                 .transparentBackground()
                 .setDoesConfirmSave(true)
                 .setSavingRunnable(() -> {
@@ -37,13 +37,13 @@ public class AutofishScreenBuilder {
                 });
 
         ConfigEntryBuilder entryBuilder = builder.entryBuilder();
-        ConfigCategory configCat = builder.getOrCreateCategory(new TranslatableText("options.autofish.config"));
+        ConfigCategory configCat = builder.getOrCreateCategory(Text.translatable("options.autofish.config"));
 
 
         //Enable Autofish
-        AbstractConfigListEntry toggleAutofish = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.enable.title"), config.isAutofishEnabled())
+        AbstractConfigListEntry toggleAutofish = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.enable.title"), config.isAutofishEnabled())
                 .setDefaultValue(defaults.isAutofishEnabled())
-                .setTooltip(new TranslatableText("options.autofish.enable.tooltip"))
+                .setTooltip(Text.translatable("options.autofish.enable.tooltip"))
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setAutofishEnabled(newValue);
                 })
@@ -51,12 +51,12 @@ public class AutofishScreenBuilder {
                 .build();
 
         //Enable MultiRod
-        AbstractConfigListEntry toggleMultiRod = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.multirod.title"), config.isMultiRod())
+        AbstractConfigListEntry toggleMultiRod = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.multirod.title"), config.isMultiRod())
                 .setDefaultValue(defaults.isMultiRod())
                 .setTooltip(
-                        new TranslatableText("options.autofish.multirod.tooltip_0"),
-                        new TranslatableText("options.autofish.multirod.tooltip_1"),
-                        new TranslatableText("options.autofish.multirod.tooltip_2")
+                        Text.translatable("options.autofish.multirod.tooltip_0"),
+                        Text.translatable("options.autofish.multirod.tooltip_1"),
+                        Text.translatable("options.autofish.multirod.tooltip_2")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setMultiRod(newValue);
@@ -65,11 +65,11 @@ public class AutofishScreenBuilder {
                 .build();
 
         //Enable Break Protection
-        AbstractConfigListEntry toggleBreakProtection = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.break_protection.title"), config.isNoBreak())
+        AbstractConfigListEntry toggleBreakProtection = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.break_protection.title"), config.isNoBreak())
                 .setDefaultValue(defaults.isNoBreak())
                 .setTooltip(
-                        new TranslatableText("options.autofish.break_protection.tooltip_0"),
-                        new TranslatableText("options.autofish.break_protection.tooltip_1")
+                        Text.translatable("options.autofish.break_protection.tooltip_0"),
+                        Text.translatable("options.autofish.break_protection.tooltip_1")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setNoBreak(newValue);
@@ -78,15 +78,15 @@ public class AutofishScreenBuilder {
                 .build();
 
         //Enable Persistent Mode
-        AbstractConfigListEntry togglePersistentMode = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.persistent.title"), config.isPersistentMode())
+        AbstractConfigListEntry togglePersistentMode = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.persistent.title"), config.isPersistentMode())
                 .setDefaultValue(defaults.isPersistentMode())
                 .setTooltip(
-                        new TranslatableText("options.autofish.persistent.tooltip_0"),
-                        new TranslatableText("options.autofish.persistent.tooltip_1"),
-                        new TranslatableText("options.autofish.persistent.tooltip_2"),
-                        new TranslatableText("options.autofish.persistent.tooltip_3"),
-                        new TranslatableText("options.autofish.persistent.tooltip_4"),
-                        new TranslatableText("options.autofish.persistent.tooltip_5")
+                        Text.translatable("options.autofish.persistent.tooltip_0"),
+                        Text.translatable("options.autofish.persistent.tooltip_1"),
+                        Text.translatable("options.autofish.persistent.tooltip_2"),
+                        Text.translatable("options.autofish.persistent.tooltip_3"),
+                        Text.translatable("options.autofish.persistent.tooltip_4"),
+                        Text.translatable("options.autofish.persistent.tooltip_5")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setPersistentMode(newValue);
@@ -96,19 +96,19 @@ public class AutofishScreenBuilder {
 
 
         //Enable Sound Detection
-        AbstractConfigListEntry toggleSoundDetection = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.sound.title"), config.isUseSoundDetection())
+        AbstractConfigListEntry toggleSoundDetection = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.sound.title"), config.isUseSoundDetection())
                 .setDefaultValue(defaults.isUseSoundDetection())
                 .setTooltip(
-                        new TranslatableText("options.autofish.sound.tooltip_0"),
-                        new TranslatableText("options.autofish.sound.tooltip_1"),
-                        new TranslatableText("options.autofish.sound.tooltip_2"),
-                        new TranslatableText("options.autofish.sound.tooltip_3"),
-                        new TranslatableText("options.autofish.sound.tooltip_4"),
-                        new TranslatableText("options.autofish.sound.tooltip_5"),
-                        new TranslatableText("options.autofish.sound.tooltip_6"),
-                        new TranslatableText("options.autofish.sound.tooltip_7"),
-                        new TranslatableText("options.autofish.sound.tooltip_8"),
-                        new TranslatableText("options.autofish.sound.tooltip_9")
+                        Text.translatable("options.autofish.sound.tooltip_0"),
+                        Text.translatable("options.autofish.sound.tooltip_1"),
+                        Text.translatable("options.autofish.sound.tooltip_2"),
+                        Text.translatable("options.autofish.sound.tooltip_3"),
+                        Text.translatable("options.autofish.sound.tooltip_4"),
+                        Text.translatable("options.autofish.sound.tooltip_5"),
+                        Text.translatable("options.autofish.sound.tooltip_6"),
+                        Text.translatable("options.autofish.sound.tooltip_7"),
+                        Text.translatable("options.autofish.sound.tooltip_8"),
+                        Text.translatable("options.autofish.sound.tooltip_9")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setUseSoundDetection(newValue);
@@ -118,12 +118,12 @@ public class AutofishScreenBuilder {
                 .build();
 
         //Enable Force MP Detection
-        AbstractConfigListEntry toggleForceMPDetection = entryBuilder.startBooleanToggle(new TranslatableText("options.autofish.multiplayer_compat.title"), config.isForceMPDetection())
+        AbstractConfigListEntry toggleForceMPDetection = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.multiplayer_compat.title"), config.isForceMPDetection())
                 .setDefaultValue(defaults.isPersistentMode())
                 .setTooltip(
-                        new TranslatableText("options.autofish.multiplayer_compat.tooltip_0"),
-                        new TranslatableText("options.autofish.multiplayer_compat.tooltip_1"),
-                        new TranslatableText("options.autofish.multiplayer_compat.tooltip_2")
+                        Text.translatable("options.autofish.multiplayer_compat.tooltip_0"),
+                        Text.translatable("options.autofish.multiplayer_compat.tooltip_1"),
+                        Text.translatable("options.autofish.multiplayer_compat.tooltip_2")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setForceMPDetection(newValue);
@@ -132,25 +132,25 @@ public class AutofishScreenBuilder {
                 .build();
 
         //Recast Delay
-        AbstractConfigListEntry recastDelaySlider = entryBuilder.startLongSlider(new TranslatableText("options.autofish.recast_delay.title"), config.getRecastDelay(), 1000, 5000)
+        AbstractConfigListEntry recastDelaySlider = entryBuilder.startLongSlider(Text.translatable("options.autofish.recast_delay.title"), config.getRecastDelay(), 1000, 5000)
                 .setDefaultValue(defaults.getRecastDelay())
                 .setTooltip(
-                        new TranslatableText("options.autofish.recast_delay.tooltip_0"),
-                        new TranslatableText("options.autofish.recast_delay.tooltip_1")
+                        Text.translatable("options.autofish.recast_delay.tooltip_0"),
+                        Text.translatable("options.autofish.recast_delay.tooltip_1")
                 )
-                .setTextGetter(value -> new TranslatableText("options.autofish.recast_delay.value", value))
+                .setTextGetter(value -> Text.translatable("options.autofish.recast_delay.value", value))
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setRecastDelay(newValue);
                 })
                 .build();
 
         //ClearLag Regex
-        AbstractConfigListEntry clearLagRegexField = entryBuilder.startTextField(new TranslatableText("options.autofish.clear_regex.title"), config.getClearLagRegex())
+        AbstractConfigListEntry clearLagRegexField = entryBuilder.startTextField(Text.translatable("options.autofish.clear_regex.title"), config.getClearLagRegex())
                 .setDefaultValue(defaults.getClearLagRegex())
                 .setTooltip(
-                        new TranslatableText("options.autofish.clear_regex.tooltip_0"),
-                        new TranslatableText("options.autofish.clear_regex.tooltip_1"),
-                        new TranslatableText("options.autofish.clear_regex.tooltip_2")
+                        Text.translatable("options.autofish.clear_regex.tooltip_0"),
+                        Text.translatable("options.autofish.clear_regex.tooltip_1"),
+                        Text.translatable("options.autofish.clear_regex.tooltip_2")
                 )
                 .setSaveConsumer(newValue -> {
                     modAutofish.getConfig().setClearLagRegex(newValue);
@@ -158,14 +158,14 @@ public class AutofishScreenBuilder {
                 .build();
 
 
-        SubCategoryBuilder subCatBuilderBasic = entryBuilder.startSubCategory(new TranslatableText("options.autofish.basic.title"));
+        SubCategoryBuilder subCatBuilderBasic = entryBuilder.startSubCategory(Text.translatable("options.autofish.basic.title"));
         subCatBuilderBasic.add(toggleAutofish);
         subCatBuilderBasic.add(toggleMultiRod);
         subCatBuilderBasic.add(toggleBreakProtection);
         subCatBuilderBasic.add((togglePersistentMode));
         subCatBuilderBasic.setExpanded(true);
 
-        SubCategoryBuilder subCatBuilderAdvanced = entryBuilder.startSubCategory(new TranslatableText("options.autofish.advanced.title"));
+        SubCategoryBuilder subCatBuilderAdvanced = entryBuilder.startSubCategory(Text.translatable("options.autofish.advanced.title"));
         subCatBuilderAdvanced.add(toggleSoundDetection);
         subCatBuilderAdvanced.add(toggleForceMPDetection);
         subCatBuilderAdvanced.add(recastDelaySlider);


### PR DESCRIPTION
The only migration issues came from `TranslatableText` becoming `Text.translatable`, `interactItem` no longer needing a `World` (it has a reference internally now), and `GameMessageS2CPacket` not having correctly mapped `getMessage` (I expect this to be updated soon when yarn gets a version update, but for now this is what it is).

Compiles and executes flawlessly on 1.19 with no issues. Versioning for gradle was bumped up to `0.9.5` as well.