### PR TITLE
Update for 1.19.3. Fix mixin and references due to PlaySoundIdS2CPack…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.0-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 0.9.5-SNAPSHOT
+mod_version = 0.9.7-SNAPSHOT
 maven_group = troy.autofish
 archives_base_name = autofish
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html or https://fabricmc.net/use
-minecraft_version=1.19
-yarn_mappings=1.19+build.4
-loader_version=0.14.8
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.3
+loader_version=0.14.11
 
 #Fabric API
-fabric_version=0.56.1+1.19
+fabric_version=0.69.1+1.19.3
 
 #Cloth Config API
-cloth_config_version=7.0.65
+cloth_config_version=9.0.94

--- a/src/main/java/troy/autofish/mixin/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/troy/autofish/mixin/MixinClientPlayNetworkHandler.java
@@ -4,7 +4,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket;
 import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;
-import net.minecraft.network.packet.s2c.play.PlaySoundIdS2CPacket;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,11 +20,6 @@ public class MixinClientPlayNetworkHandler {
     @Inject(method = "onPlaySound", at = @At("HEAD"))
     public void onPlaySound(PlaySoundS2CPacket playSoundS2CPacket_1, CallbackInfo ci) {
         if (client.isOnThread()) FabricModAutofish.getInstance().handlePacket(playSoundS2CPacket_1);
-    }
-
-    @Inject(method = "onPlaySoundId", at = @At("HEAD"))
-    public void onPlaySoundId(PlaySoundIdS2CPacket playSoundIdS2CPacket_1, CallbackInfo ci) {
-        if (client.isOnThread()) FabricModAutofish.getInstance().handlePacket(playSoundIdS2CPacket_1);
     }
 
     @Inject(method = "onEntityVelocityUpdate", at = @At("HEAD"))

--- a/src/main/java/troy/autofish/monitor/FishMonitorMPSound.java
+++ b/src/main/java/troy/autofish/monitor/FishMonitorMPSound.java
@@ -4,8 +4,8 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.projectile.FishingBobberEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.PlaySoundFromEntityS2CPacket;
-import net.minecraft.network.packet.s2c.play.PlaySoundIdS2CPacket;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
+import net.minecraft.sound.SoundEvent;
 import troy.autofish.Autofish;
 
 public class FishMonitorMPSound implements FishMonitorMP {
@@ -23,7 +23,7 @@ public class FishMonitorMPSound implements FishMonitorMP {
     @Override
     public void handlePacket(Autofish autofish, Packet<?> packet, MinecraftClient minecraft) {
 
-        if (packet instanceof PlaySoundS2CPacket || packet instanceof PlaySoundIdS2CPacket || packet instanceof PlaySoundFromEntityS2CPacket) {
+        if (packet instanceof PlaySoundS2CPacket || packet instanceof PlaySoundFromEntityS2CPacket) {
             //TODO investigate PlaySoundFromEntityS2CPacket; i dont think its ever used for fishing but whatever
 
             String soundName;
@@ -31,13 +31,8 @@ public class FishMonitorMPSound implements FishMonitorMP {
 
             if (packet instanceof PlaySoundS2CPacket) {
                 PlaySoundS2CPacket soundPacket = (PlaySoundS2CPacket) packet;
-                soundName = soundPacket.getSound().getId().toString();
-                x = soundPacket.getX();
-                y = soundPacket.getY();
-                z = soundPacket.getZ();
-            } else if (packet instanceof PlaySoundIdS2CPacket) {
-                PlaySoundIdS2CPacket soundPacket = (PlaySoundIdS2CPacket) packet;
-                soundName = soundPacket.getSoundId().toString();
+                SoundEvent soundEvent = (SoundEvent) soundPacket.getSound();
+                soundName = soundEvent.getId().toString();
                 x = soundPacket.getX();
                 y = soundPacket.getY();
                 z = soundPacket.getZ();


### PR DESCRIPTION
Updated gradle.properties and build.gradle for latest 1.19.3 dependencies.
Removed references to PlaySoundIdS2CPacket due to removal from yarn 1.19.3+build.3 (removed since 1.19.3-rc3+build.1)
    src/main/java/troy/autofish/mixin/MixinClientPlayNetworkHandler.java -> @Inject(method = "onPlaySoundId"...
    src/main/java/troy/autofish/monitor/FishMonitorMPSound.java -> public void handlePacket
Bump version patch number from 0.9.5 -> 0.9.7 (Was using 0.9.6 for 1.19 builds)