### PR TITLE
Bump to Minecraft 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ archives_base_name = autofish
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html or https://fabricmc.net/use
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
-loader_version=0.14.14
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.17
 
 #Fabric API
-fabric_version=0.73.2+1.19.3
+fabric_version=0.76.0+1.19.4
 
 #Cloth Config API
-cloth_config_version=9.0.94
+cloth_config_version=10.0.96

--- a/src/main/java/troy/autofish/Autofish.java
+++ b/src/main/java/troy/autofish/Autofish.java
@@ -8,7 +8,7 @@ import net.minecraft.item.FishingRodItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.StringHelper;

--- a/src/main/java/troy/autofish/FabricModAutofish.java
+++ b/src/main/java/troy/autofish/FabricModAutofish.java
@@ -7,7 +7,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.Entity;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;
 import org.lwjgl.glfw.GLFW;
 import troy.autofish.config.Config;

--- a/src/main/java/troy/autofish/monitor/FishMonitorMP.java
+++ b/src/main/java/troy/autofish/monitor/FishMonitorMP.java
@@ -2,7 +2,7 @@ package troy.autofish.monitor;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.projectile.FishingBobberEntity;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import troy.autofish.Autofish;
 
 public interface FishMonitorMP {

--- a/src/main/java/troy/autofish/monitor/FishMonitorMPMotion.java
+++ b/src/main/java/troy/autofish/monitor/FishMonitorMPMotion.java
@@ -3,7 +3,7 @@ package troy.autofish.monitor;
 import net.minecraft.block.Material;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.projectile.FishingBobberEntity;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket;
 import net.minecraft.util.function.MaterialPredicate;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/troy/autofish/monitor/FishMonitorMPSound.java
+++ b/src/main/java/troy/autofish/monitor/FishMonitorMPSound.java
@@ -2,7 +2,7 @@ package troy.autofish.monitor;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.projectile.FishingBobberEntity;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.PlaySoundFromEntityS2CPacket;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import net.minecraft.sound.SoundEvent;


### PR DESCRIPTION
This bumps us up to 1.19.4 and patches some references to Packet in the latest move from `net.minecraft.network.Packet` to `net.minecraft.network.packet.Packet`.


Co-authored-by: Dylan Hackworth <dylhack@gmail.com> (@dylhack)